### PR TITLE
fix: wrongly tries to access default export when there is none

### DIFF
--- a/src/compileStyles.ts
+++ b/src/compileStyles.ts
@@ -14,15 +14,15 @@ export const compileStyles = async (
       const { content } = style
 
       if (style.lang === 'stylus') {
-        style.content = await require('./style-compilers/stylus')(content, {
+        style.content = await require('./style-compilers/stylus').compile(content, {
           filename
         })
       } else if (!style.lang || style.lang === 'postcss') {
-        style.content = await require('./style-compilers/postcss')(content, {
+        style.content = await require('./style-compilers/postcss').compile(content, {
           filename
         })
       } else if (style.lang === 'scss' || style.lang === 'sass') {
-        style.content = await require('./style-compilers/sass')(content, {
+        style.content = await require('./style-compilers/sass').compile(content, {
           filename,
           indentedSyntax: style.lang === 'sass'
         })


### PR DESCRIPTION
fixes #180 

I'm not sure how this bug snuck in, but I noticed when I couldn't compile, because

in `compileStyles.ts` it kept saying `require(...)` is not a function!

And when I double checked, I noticed that indeed, whatever `require(...)` was importing is an object with `{ compile }` like so.